### PR TITLE
Ambiguous reference to utils

### DIFF
--- a/SMTPMail.cc
+++ b/SMTPMail.cc
@@ -84,7 +84,7 @@ struct EMail
           m_passwd(passwd),
           m_socket(socket),
           m_isHTML(isHTML),
-          m_uuid(utils::getUuid())
+          m_uuid(drogon::utils::getUuid())
     {
         m_status = Init;
     }
@@ -201,7 +201,7 @@ void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
 
         // outMsg.append(base64_encode(reinterpret_cast<const unsigned
         // char*>(screte.c_str()), screte.length()));
-        outMsg.append(utils::base64Encode(
+        outMsg.append(drogon::utils::base64Encode(
             reinterpret_cast<const unsigned char *>(screte.c_str()),
             screte.length()));
 
@@ -220,7 +220,7 @@ void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
 
         std::string screte(email->m_passwd);
 
-        outMsg.append(utils::base64Encode(
+        outMsg.append(drogon::utils::base64Encode(
             reinterpret_cast<const unsigned char *>(screte.c_str()),
             screte.length()));
         outMsg.append("\r\n");


### PR DESCRIPTION
Trying to compile the plugin with the latest version of trantor and v1.7.3 of drogon, the utils namespace is ambiguous. The issue is resolved by specifying that the referred namespace is actually `drogon::utils`.

Compiler output:
```
/.../plugins/SMTPMail-drogon/SMTPMail.cc: In constructor ‘EMail::EMail(const string&, const string&, const string&, const string&, const string&, const string&, bool, std::shared_ptr<trantor::TcpClient>)’:
/.../plugins/SMTPMail-drogon/SMTPMail.cc:87:18: error: reference to ‘utils’ is ambiguous
   87 |           m_uuid(utils::getUuid())
      |                  ^~~~~
In file included from /usr/local/include/drogon/utils/Utilities.h:20,
                 from /usr/local/include/drogon/HttpBinder.h:24,
                 from /usr/local/include/drogon/HttpAppFramework.h:21,
                 from /.../plugins/SMTPMail-drogon/SMTPMail.cc:37:
/usr/local/include/trantor/utils/Utilities.h:26:11: note: candidates are: ‘namespace trantor::utils { }’
   26 | namespace utils
      |           ^~~~~
In file included from /usr/local/include/drogon/HttpBinder.h:24,
                 from /usr/local/include/drogon/HttpAppFramework.h:21,
                 from /.../plugins/SMTPMail-drogon/SMTPMail.cc:37:
/usr/local/include/drogon/utils/Utilities.h:58:11: note:                 ‘namespace drogon::utils { }’
   58 | namespace utils
      |           ^~~~~
...
```
