### PR TITLE
Fix minor Clang-Tidy warnings and misspellings

### DIFF
--- a/SMTPMail.cc
+++ b/SMTPMail.cc
@@ -2,7 +2,7 @@
 *
 * SMTPMail.cc *
 *
-* This plugin is for SMTP mail delievery for the Drogon web-framework.
+* This plugin is for SMTP mail delivery for the Drogon web-framework.
 Implementation
 * reference from the project "SMTPClient" with Qt5 by kelvins. Please check out
 * https://github.com/kelvins/SMTPClient.
@@ -114,17 +114,17 @@ void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
                     const std::shared_ptr<EMail>& email,
                     const std::function<void(const std::string &msg)> &cb)
 {
-    std::string receievedMsg;
+    std::string receivedMsg;
     while (msg->readableBytes() > 0)
     {
         std::string buf(msg->peek(), msg->readableBytes());
-        receievedMsg.append(buf);
+        receivedMsg.append(buf);
         //        LOG_INFO << buf;
         msg->retrieveAll();
     }
-    LOG_TRACE << "receive: " << receievedMsg;
-    std::string responseCode(receievedMsg.begin(), receievedMsg.begin() + 3);
-    //    std::string responseMsg(receievedMsg.begin() + 4, receievedMsg.end());
+    LOG_TRACE << "receive: " << receivedMsg;
+    std::string responseCode(receivedMsg.begin(), receivedMsg.begin() + 3);
+    //    std::string responseMsg(receivedMsg.begin() + 4, receivedMsg.end());
 
     if (email->m_status == EMail::Init && responseCode == "220")
     {
@@ -194,13 +194,13 @@ void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
         trantor::MsgBuffer out;
         std::string outMsg;
 
-        std::string screte(email->m_user);
+        std::string secret(email->m_user);
 
         // outMsg.append(base64_encode(reinterpret_cast<const unsigned
-        // char*>(screte.c_str()), screte.length()));
+        // char*>(secret.c_str()), secret.length()));
         outMsg.append(drogon::utils::base64Encode(
-            reinterpret_cast<const unsigned char *>(screte.c_str()),
-            screte.length()));
+                reinterpret_cast<const unsigned char *>(secret.c_str()),
+                secret.length()));
 
         outMsg.append("\r\n");
 
@@ -215,11 +215,11 @@ void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
         trantor::MsgBuffer out;
         std::string outMsg;
 
-        std::string screte(email->m_passwd);
+        std::string secret(email->m_passwd);
 
         outMsg.append(drogon::utils::base64Encode(
-            reinterpret_cast<const unsigned char *>(screte.c_str()),
-            screte.length()));
+                reinterpret_cast<const unsigned char *>(secret.c_str()),
+                secret.length()));
         outMsg.append("\r\n");
 
         out.append(outMsg.data(), outMsg.size());
@@ -310,15 +310,15 @@ void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
     }
     else if (email->m_status == EMail::Close)
     {
-        /*Callback here for succeed delievery is propable*/
+        /*Callback here for succeed delivery is probable*/
         cb("EMail sent. ID : " + email->m_uuid);
         return;
     }
     else
     {
         email->m_status = EMail::Close;
-        /*Callback here for notification is propable*/
-        cb(receievedMsg);
+        /*Callback here for notification is probable*/
+        cb(receivedMsg);
     }
 }
 

--- a/SMTPMail.cc
+++ b/SMTPMail.cc
@@ -111,7 +111,7 @@ void SMTPMail::shutdown()
 
 void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
                     trantor::MsgBuffer *msg,
-                    std::shared_ptr<EMail> email,
+                    const std::shared_ptr<EMail>& email,
                     const std::function<void(const std::string &msg)> &cb)
 {
     auto msgSize = msg->readableBytes();

--- a/SMTPMail.cc
+++ b/SMTPMail.cc
@@ -68,21 +68,21 @@ struct EMail
     bool m_isHTML{false};
     std::shared_ptr<trantor::TcpClient> m_socket;
 
-    EMail(const std::string &from,
-          const std::string &to,
-          const std::string &subject,
-          const std::string &content,
-          const std::string &user,
-          const std::string &passwd,
+    EMail(std::string from,
+          std::string to,
+          std::string subject,
+          std::string content,
+          std::string user,
+          std::string passwd,
           bool isHTML,
           std::shared_ptr<trantor::TcpClient> socket)
-        : m_from(from),
-          m_to(to),
-          m_subject(subject),
-          m_content(content),
-          m_user(user),
-          m_passwd(passwd),
-          m_socket(socket),
+        : m_from(std::move(from)),
+          m_to(std::move(to)),
+          m_subject(std::move(subject)),
+          m_content(std::move(content)),
+          m_user(std::move(user)),
+          m_passwd(std::move(passwd)),
+          m_socket(std::move(socket)),
           m_isHTML(isHTML),
           m_uuid(drogon::utils::getUuid())
     {

--- a/SMTPMail.cc
+++ b/SMTPMail.cc
@@ -343,7 +343,7 @@ std::string SMTPMail::sendEmail(
                  << "\nfrom : " << from << "\nto : " << to
                  << "\nsubject : " << subject << "\nuser : " << user
                  << "\npasswd : " << passwd;
-        return std::string();
+        return {};
     }
     LOG_TRACE << "New TcpClient : " << mailServer << ":" << port;
 

--- a/SMTPMail.cc
+++ b/SMTPMail.cc
@@ -155,7 +155,7 @@ void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
             [connPtr, out]()
             {
                 // LOG_TRACE << "SSL established";
-                connPtr->send(std::move(out));
+                connPtr->send(out);
             },
             false,
             false);

--- a/SMTPMail.cc
+++ b/SMTPMail.cc
@@ -114,7 +114,6 @@ void messagesHandle(const trantor::TcpConnectionPtr &connPtr,
                     const std::shared_ptr<EMail>& email,
                     const std::function<void(const std::string &msg)> &cb)
 {
-    auto msgSize = msg->readableBytes();
     std::string receievedMsg;
     while (msg->readableBytes() > 0)
     {

--- a/SMTPMail.cc
+++ b/SMTPMail.cc
@@ -89,9 +89,7 @@ struct EMail
         m_status = Init;
     }
 
-    ~EMail()
-    {
-    }
+    ~EMail() = default;
 
     static std::unordered_map<std::string, std::shared_ptr<EMail>>
         m_emails;  // Container for processing emails

--- a/SMTPMail.h
+++ b/SMTPMail.h
@@ -38,11 +38,11 @@ class SMTPMail : public drogon::Plugin<SMTPMail>
     SMTPMail() = default;
     /// This method must be called by drogon to initialize and start the plugin.
     /// It must be implemented by the user.
-    virtual void initAndStart(const Json::Value &config) override;
+    void initAndStart(const Json::Value &config) override;
 
     /// This method must be called by drogon to shutdown the plugin.
     /// It must be implemented by the user.
-    virtual void shutdown() override;
+    void shutdown() override;
 
     /** Send an email
      * return : An ID of the email.

--- a/SMTPMail.h
+++ b/SMTPMail.h
@@ -35,9 +35,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 class SMTPMail : public drogon::Plugin<SMTPMail>
 {
   public:
-    SMTPMail()
-    {
-    }
+    SMTPMail() = default;
     /// This method must be called by drogon to initialize and start the plugin.
     /// It must be implemented by the user.
     virtual void initAndStart(const Json::Value &config) override;


### PR DESCRIPTION
There's still an "initialize in static storage may cause an exception that cannot be caught" warning which I don't know how to fix yet. Maybe make struct "Email" as private subclass in SMTPMail would work.